### PR TITLE
:bug: [bug fix] 修复react-native-orientation package 导致打包失败的问题

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,17 @@ allprojects {
     }
 }
 
+subprojects {
+    afterEvaluate { project ->
+        if (project.hasProperty("android")) {
+            android {
+                compileSdkVersion 27        // version of compile sdk used for project
+                buildToolsVersion '27.0.3'    // version of build tool used for project
+            }
+        }
+    }
+}
+
 
 task wrapper(type: Wrapper) {
     gradleVersion = '4.4'


### PR DESCRIPTION
打包平台：win10
安卓打包错误：
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-orientation:verifyReleaseResources'.
> com.android.ide.common.process.ProcessException: Failed to execute aapt

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

解决方法：Add subprojects {} to android/build.gradle

BUILD SUCCESSFUL in 3m 21s
168 actionable tasks: 34 executed, 134 up-to-date